### PR TITLE
Fix syntax errors in IDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -220,7 +220,7 @@ spec:dom; type:interface; text:Document
 
 	<h3 id='visibility-observer-callback'>The VisibilityObserverCallback</h3>
 		<pre class='idl'>
-			callback VisibilityObserverCallback = void(sequence&lt;VisibilityObserverEntry&gt; entries, VisibilityObserver observer)
+			callback VisibilityObserverCallback = void(sequence&lt;VisibilityObserverEntry&gt; entries, VisibilityObserver observer);
 		</pre>
 		This callback will be invoked when there are changes to the document's <em>visibility state</em>.
 
@@ -301,9 +301,9 @@ spec:dom; type:interface; text:Document
 		<pre class="idl">
  	     dictionary VisibilityObserverInit {
  	       (double or sequence&lt;double&gt;) areaThreshold = 0;
-				 (boolean) displacementAware = false;
-				 (DOMString) visibleMargin = "0px";
-				 (Element)? observedElement;
+				 boolean displacementAware = false;
+				 DOMString visibleMargin = "0px";
+				 Element? observedElement;
  	     };
 		</pre>
 


### PR DESCRIPTION
From output while writing https://github.com/web-platform-tests/wpt/pull/11795

> Got an error during or right after parsing `callback VisibilityObserverCallback`: Unterminated callback

> Got an error during or right after parsing `dictionary VisibilityObserverInit`: At least two types are expected in a union type but found less